### PR TITLE
fix: Add DATABASE_URL env var to Prisma generate step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Generate Prisma Client
         working-directory: ./ghl-api
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npx prisma generate
 
       - name: Build backend


### PR DESCRIPTION
Prisma generate needs DATABASE_URL to load the prisma.config.ts file